### PR TITLE
Merge tag 'android-6.0.1_r55' into marshmallow-caf

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
   <remote  name="github"
            fetch="https://github.com" />
 
-  <default revision="refs/tags/android-6.0.1_r16"
+  <default revision="refs/tags/android-6.0.1_r55"
            remote="aosp"
            sync-j="4" />
 


### PR DESCRIPTION
Android 6.0.1 Release 55 (MXC89K)
